### PR TITLE
Update ecstatic to 0.5.x

### DIFF
--- a/templates/bin/node/http-server/package.json
+++ b/templates/bin/node/http-server/package.json
@@ -53,7 +53,7 @@
     "colors": "0.6.x",
     "optimist": "0.5.x",
     "union": "0.3.x",
-    "ecstatic": "0.4.x",
+    "ecstatic": "0.5.x",
     "portfinder": "0.2.x",
     "opener": "~1.3.0"
   },


### PR DESCRIPTION
0.5.x is the lowest version that supports videos for iOS devices (byte-ranges).
